### PR TITLE
Add alternative application method via email

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,7 @@
         W3C Workshop on Permissions
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
     <!-- <style>
     body {
           background-image: url('data:image/svg+xml,\
@@ -25,7 +25,9 @@
 
 <body>
         {% include header.html %}
-        {% include toc.html %}
+        {% if page.toc %}
+            {% include toc.html %}
+        {% endif %}
     <main id="main" class="main">
         <section id="home">
             {{ content }}

--- a/application-questions.md
+++ b/application-questions.md
@@ -1,0 +1,45 @@
+---
+title: Application questions
+permalink: /application-questions/
+layout: home
+---
+
+# Apply to attend the workshop
+
+To submit an application to attend the workshop, please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSePSeO6YmmENDmTsuBD5OCY0ZkfyGKFaQ5THojWMcE0p1Q_XQ/viewform). If this is not possible, please answer the questions below and email your answers to [permissions-ws-2022-committee@chromium.org](mailto:permissions-ws-2022-committee@chromium.org).
+
+Applying to the workshop does not guarantee an invitation. Invitations will be sent on or about November 7. You are encouraged to delay making non-refundable travel plans until then.
+
+# Application questions
+
+- Name
+- Email address
+- Affiliation
+- Which days would you like to attend? (Select all that apply)
+  - Monday, 5th December 2022
+  - Tuesday, 6th December 2022
+- Do you plan to attend remotely or in person?
+  - If you are attending remotely, which timezone will you be attending from?
+
+## Subject matter questions
+
+Do you have research to share, an implementation or prototype to demonstrate, or a proposal to present? Please provide links and/or a brief explanation.
+What do you view as the single biggest shortcoming or challenge of the permission models deployed today?
+
+Position Statement
+Additionally, you are encouraged to submit a short position statement. Please submit your position paper at the latest by Oct 26, 2022, by:
+  1) Adding it to the [https://github.com/w3c/permissions-ws-2022/tree/main/papers](https://github.com/w3c/permissions-ws-2022/tree/main/papers)  directory, and
+  2) Opening a pull request at [https://github.com/w3c/permissions-ws-2022/pulls](https://github.com/w3c/permissions-ws-2022/pulls).
+
+Alternatively, you can email your statement to the program committee at permissions-ws-2022-committee@chromium.org. More information can be found on our website. 
+
+## Logistics
+
+- Do you have any accessibility requirements?
+- Do you have any food allergies / preferences?
+
+All on-site attendees are required to self-test for COVID before arriving at the venue each day, and are required to wear a mask at all times except when eating or drinking.
+
+Here is our [full list of COVID health measures](/#covid-health-measures).
+
+Please acknowledge that you understand and agree to these COVID measures.

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ The workshop will build on the [W3C Workshop on Permissions and User Consent hel
 
 Attendance is free for all invited participants and is open to the public, whether or not W3C members.
 
-If you wish to express interest in attending, please fill out the [application form](https://docs.google.com/forms/d/e/1FAIpQLSePSeO6YmmENDmTsuBD5OCY0ZkfyGKFaQ5THojWMcE0p1Q_XQ/viewform?usp=sf_link). The application form asks several questions about your background and ideas; please give these questions serious thought. In addition to the application form, you are encouraged to [submit](#how-can-i-suggest-a-presentation) a position statement and/or presentation topic.
+If you wish to express interest in attending, please fill out the [application form](https://docs.google.com/forms/d/e/1FAIpQLSePSeO6YmmENDmTsuBD5OCY0ZkfyGKFaQ5THojWMcE0p1Q_XQ/viewform?usp=sf_link). The application form asks several questions about your background and ideas; please give these questions serious thought. In addition to the application form, you are encouraged to [submit](#how-can-i-suggest-a-presentation) a position statement and/or presentation topic. If you cannot use the application form, please answer the [application questions](/application-questions/) and email your answers to [permissions-ws-2022-committee@chromium.org](mailto:permissions-ws-2022-committee@chromium.org)
 
 Because the venue has limited space, you must receive an acceptance email to attend. You might wish to defer making non-refundable travel arrangements until you receive an invitation. Be sure to keep an eye on these important dates.
 

--- a/index.md
+++ b/index.md
@@ -67,7 +67,7 @@ A good position statement should be a few paragraphs long and should include:
 
 Submissions should be between 200 and 1000 words.
 
-Please submit statements to the program committee by adding your statement to the [position papers directory](https://github.com/w3c/permissions-ws-2022/tree/master/papers) and opening a [pull request](https://github.com/w3c/permissions-ws-2022/pulls). Alternatively, you can email your statement to the program committee at [permissions-ws-2022-committee@chromium.org](mailto:permissions-ws-2022-committee@chromium.org).
+Please submit statements to the program committee by adding your statement to the [position papers directory](https://github.com/w3c/permissions-ws-2022/tree/main/papers) and opening a [pull request](https://github.com/w3c/permissions-ws-2022/pulls). Alternatively, you can email your statement to the program committee at [permissions-ws-2022-committee@chromium.org](mailto:permissions-ws-2022-committee@chromium.org).
 
 # Location and Time
 


### PR DESCRIPTION
Copied over application questions from [the Google Form](https://docs.google.com/forms/d/e/1FAIpQLSePSeO6YmmENDmTsuBD5OCY0ZkfyGKFaQ5THojWMcE0p1Q_XQ/viewform) 
 to the website so people can apply over email if required.